### PR TITLE
添加对rules.csv中script列的特殊处理，只输出带文本的脚本内容作为词条

### DIFF
--- a/para_tranz/para_tranz_map.json
+++ b/para_tranz/para_tranz_map.json
@@ -52,6 +52,7 @@
     "translation_path": "data/campaign/rules汉化校对测试样本(手动替换以测试).csv",
     "id_column_name": "id",
     "text_column_names": [
+      "script",
       "text",
       "options"
     ]


### PR DESCRIPTION
优化了导出的paratranz json文件的格式，添加了stage属性来指定词条翻译状态